### PR TITLE
Feature/compile with macos icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Should the user be able to resize the window? Default: true
 
 Platform specific settings
 
+#### platform.asar
+
+Whether or not to archive the source to an asar or not. Default: true
+
 ### platform.macos
 
 #### platform.macos.autoClose
@@ -92,6 +96,8 @@ You can now include a config file that will help prepare your desktop apps. This
 ### 0.5.0
 
 Reduced the binary size by ~100mb. No changes required on the developer's end. Polyonic will doesn't copy node_modules anymore but re-generates the package.json and installs only the required modules for release.
+
+MacOS builds will now build with a custom icon.
 
 ### 0.0.4
 

--- a/src/polyonic.config.js
+++ b/src/polyonic.config.js
@@ -1,6 +1,6 @@
 const fs = require('fs-extra');
 
-var config = fs.readJsonSync('polyonic.config.json');
+var config = fs.readJsonSync(__dirname + '/polyonic.config.json');
 
 // Do some cool config normalizing or something here
 
@@ -64,6 +64,10 @@ if(!checkNested(config, 'debug', 'devTools')) {
 
 if(!checkNested(config, 'platform')) {
   config.platform = {};
+}
+
+if(!checkNested(config, 'platform', 'asar')) {
+  config.platform.asar = true;
 }
 
 if(!checkNested(config, 'platform', 'macos')) {

--- a/src/polyonic.config.json
+++ b/src/polyonic.config.json
@@ -10,6 +10,7 @@
     "devTools": true
   },
   "platform": {
+    "asar": false,
     "macos": {
       "autoClose": true
     }

--- a/tasks/build/build.js
+++ b/tasks/build/build.js
@@ -20,6 +20,8 @@ const srcDir = projectDir.cwd('./src');
 const destDir = projectDir.cwd('./build');
 const binDir = projectDir.cwd('./test-darwin-x64');
 
+const config              = require(srcDir.path('./polyonic.config.js'));
+
 let paths = {
   copyFromAppDir: [
     './www/**',
@@ -31,6 +33,10 @@ let paths = {
 // -------------------------------------
 // Tasks
 // -------------------------------------
+
+gulp.task('testBuild', function() {
+  // Quickly validate that we didn't break anything here
+})
 
 gulp.task('clean', function (done) {
   destDir.dirAsync('.', { empty: true }).then(function() {
@@ -113,13 +119,22 @@ gulp.task('build-electron', function(done) {
   parseString(configXml, function (err, result) {
     var appVersion = result.widget.$.version;
 
+    var iconFile = null;
+
+    switch(process.platform) {
+      case 'darwin':
+        iconFile = projectDir.path('./resources/osx/icon.icns');
+      break;
+    }
+
     packager({
       dir: 'build',
-      asar: true,
+      asar: config.platform.asar,
       // todo: icon
       overwrite: true,
       out: 'output',
-      appVersion: appVersion
+      appVersion: appVersion,
+      icon: iconFile
     }, function (err, appPaths) {
       done(err);
     });


### PR DESCRIPTION
#### Short description of what this resolves:

- Compile with MacOS icons
- Fixed a bug where apps wouldn't launch from a build because of the config file